### PR TITLE
Fix wrong timestamp. The 'm' in the timestamp always put the actual m…

### DIFF
--- a/pvoutput/__init__.py
+++ b/pvoutput/__init__.py
@@ -22,8 +22,8 @@ class PvOutputApi(object):
 
         parameters = {
             'c': "1" if self.cumulative else "0",
-            'd': "%Y%m%d".format(time),
-            't': "%H:%m".format(time)
+            'd': time.strftime("%Y%m%d"),
+            't': time.strftime("%H:%M")
         }
 
         if energy_generation:


### PR DESCRIPTION
Fix wrong timestamp. The 'm' in the timestamp always put the actual month as value for the minute. ==> use %M
